### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     outputs:
       has-new-release: ${{ steps.release.outputs.new_release_published }}
       tag-name: ${{ steps.release.outputs.new_release_git_tag }}
@@ -28,6 +32,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: release
     if: needs.release.outputs.has-new-release == 'true'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/thihathit/rutter/security/code-scanning/8](https://github.com/thihathit/rutter/security/code-scanning/8)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (top-level), so all jobs inherit least-privilege defaults.  
Best single change without altering intended functionality is to set:

- `contents: read`

This satisfies checkout/read-only CI tasks and addresses CodeQL’s requirement. If any step later fails due to missing scopes, add only the specific additional permission needed at that job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
